### PR TITLE
[DEM-1740] Reverse folder order and implement Import Status column

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,6 @@
   },
   "homepage": "https://github.com/uptick/react-keyed-file-browser#readme",
   "dependencies": {
-    "classnames": "^2.2.3",
-    "moment": "^2.17.0",
-    "prop-types": "^15.5.8",
-    "react-dnd": "^2.1.4",
-    "react-dnd-html5-backend": "^2.1.2"
     "classnames": "^2.2.6",
     "moment": "^2.24.0",
     "prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
     "prop-types": "^15.5.8",
     "react-dnd": "^2.1.4",
     "react-dnd-html5-backend": "^2.1.2"
+    "classnames": "^2.2.6",
+    "moment": "^2.24.0",
+    "prop-types": "^15.7.2",
+    "react-dnd": "^5.0.0",
+    "react-dnd-html5-backend": "^5.0.1"
   },
   "peerDependencies": {
     "react": "0.14.x || 15.x || 16.x",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-keyed-file-browser",
+  "name": "@bauerpub/bauer-react-keyed-file-browser",
   "version": "1.4.3",
   "description": "Folder based file browser given a flat keyed list of objects, powered by React.",
   "main": "index.js",
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/uptick/react-keyed-file-browser.git"
+    "url": "git+https://github.com/bauerpub/bauer-react-keyed-file-browser"
   },
   "keywords": [
     "react",

--- a/src/files/table.js
+++ b/src/files/table.js
@@ -7,12 +7,14 @@ import { NativeTypes } from 'react-dnd-html5-backend'
 import BaseFile, { BaseFileConnectors } from './../base-file.js'
 import { fileSize } from './utils.js'
 
+
 class RawTableFile extends BaseFile {
   render() {
     const {
       isDragging, isDeleting, isRenaming, isOver, isSelected,
       action, url, browserProps, connectDragPreview,
       depth, size, modified,
+      depth, last_modified, createdAt,
     } = this.props
 
     const icon = browserProps.icons[this.getFileType()] || browserProps.icons.File
@@ -90,8 +92,10 @@ class RawTableFile extends BaseFile {
           </div>
         </td>
         <td className="size">{fileSize(size)}</td>
+        <td className="created-at">{typeof createdAt === 'undefined' ? '-' : Moment(createdAt).calendar()}</td>
         <td className="modified">
           {typeof modified === 'undefined' ? '-' : Moment(modified, 'x').fromNow()}
+          {typeof last_modified === 'undefined' ? '-' : Moment(last_modified).fromNow()}
         </td>
       </tr>
     )

--- a/src/files/table.js
+++ b/src/files/table.js
@@ -5,7 +5,6 @@ import { DragSource, DropTarget } from 'react-dnd'
 import { NativeTypes } from 'react-dnd-html5-backend'
 
 import BaseFile, { BaseFileConnectors } from './../base-file.js'
-import { fileSize } from './utils.js'
 
 
 class RawTableFile extends BaseFile {
@@ -13,13 +12,11 @@ class RawTableFile extends BaseFile {
     const {
       isDragging, isDeleting, isRenaming, isOver, isSelected,
       action, url, browserProps, connectDragPreview,
-      depth, size, modified,
       depth, last_modified, createdAt,
     } = this.props
 
     const icon = browserProps.icons[this.getFileType()] || browserProps.icons.File
     const inAction = (isDragging || action)
-
     let name
     if (!inAction && isDeleting) {
       name = (
@@ -91,10 +88,8 @@ class RawTableFile extends BaseFile {
             {draggable}
           </div>
         </td>
-        <td className="size">{fileSize(size)}</td>
         <td className="created-at">{typeof createdAt === 'undefined' ? '-' : Moment(createdAt).calendar()}</td>
         <td className="modified">
-          {typeof modified === 'undefined' ? '-' : Moment(modified, 'x').fromNow()}
           {typeof last_modified === 'undefined' ? '-' : Moment(last_modified).fromNow()}
         </td>
       </tr>

--- a/src/headers/table.js
+++ b/src/headers/table.js
@@ -37,6 +37,7 @@ class RawTableHeader extends React.Component {
       >
         <th>File</th>
         <th className="size">Size</th>
+        <th className="created-at">Import Status</th>
         <th className="modified">Last Modified</th>
       </tr>
     )

--- a/src/headers/table.js
+++ b/src/headers/table.js
@@ -36,7 +36,6 @@ class RawTableHeader extends React.Component {
         })}
       >
         <th>File</th>
-        <th className="size">Size</th>
         <th className="created-at">Import Status</th>
         <th className="modified">Last Modified</th>
       </tr>

--- a/src/sorters/by-name.js
+++ b/src/sorters/by-name.js
@@ -38,7 +38,6 @@ function naturalSort(allFiles) {
   }
 
   let sortedFiles = []
-  sortedFiles = sortedFiles.concat(folders)
   sortedFiles = sortedFiles.concat(folders).reverse()
   sortedFiles = sortedFiles.concat(files)
   return sortedFiles

--- a/src/sorters/by-name.js
+++ b/src/sorters/by-name.js
@@ -39,6 +39,7 @@ function naturalSort(allFiles) {
 
   let sortedFiles = []
   sortedFiles = sortedFiles.concat(folders)
+  sortedFiles = sortedFiles.concat(folders).reverse()
   sortedFiles = sortedFiles.concat(files)
   return sortedFiles
 }

--- a/src/table-style.sass
+++ b/src/table-style.sass
@@ -22,7 +22,7 @@ div.rendered-react-keyed-file-browser
       font-weight: bold
 
     th, td
-      &.size, &.modified
+      &.created-at, &.modified
         text-align: right
 
       &.name


### PR DESCRIPTION
This pull request implements reverse chronological order of folders and an Import Status column in the file browser. It maintains the git history of the original uptick/react-keyed-file-browser repo, from which this is forked.